### PR TITLE
use_icu_alternatives_on_android feature porting.

### DIFF
--- a/build/android/clean_up_icu_data.py
+++ b/build/android/clean_up_icu_data.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+# Copyright 2011 The Chromium Authors. All rights reserved.
+# Copyright (c) 2014 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import fnmatch
+import optparse
+import os
+import sys
+
+
+def FindInDirectory(directory, filename_filter):
+  files = []
+  for root, _dirnames, filenames in os.walk(directory):
+    if os.path.abspath(directory) == os.path.abspath(root):
+      continue
+    matched_files = fnmatch.filter(filenames, filename_filter)
+    files.extend((os.path.join(root, f) for f in matched_files))
+  return files
+
+
+def main():
+  parser = optparse.OptionParser()
+  info = ('product dir to clean up icu data files in')
+  parser.add_option('--product-dir', help=info)
+  options, _ = parser.parse_args()
+
+  icu_datas = FindInDirectory(options.product_dir, 'icudtl.dat')
+  for icu_data in icu_datas:
+    os.remove(icu_data)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -125,11 +125,11 @@ def CopyBinaries(out_dir, out_project_dir, src_package, shared, no_icu_data):
   if not os.path.exists(res_value_dir):
     os.mkdir(res_value_dir)
 
-  paks = [
+  paks_to_copy = [
       'xwalk.pak',
   ]
   if not no_icu_data:
-    paks.append('icudtl.dat')
+    paks_to_copy.append('icudtl.dat')
 
   pak_list_xml = Document()
   resources_node = pak_list_xml.createElement('resources')

--- a/build/android/generate_xwalk_core_library.py
+++ b/build/android/generate_xwalk_core_library.py
@@ -29,6 +29,10 @@ def AddGeneratorOptions(option_parser):
   option_parser.add_option('--src-package', action='store_true',
                            default=False,
                            help='Use java sources instead of java libs.')
+  option_parser.add_option('--no-icu-data', action='store_true',
+                           default=False,
+                           help='Exclude icudtl.dat when specified')
+
 
 def CleanLibraryProject(out_project_dir):
   if os.path.exists(out_project_dir):
@@ -91,7 +95,7 @@ def CopyJSBindingFiles(project_source, out_project_dir):
     shutil.copyfile(source_file, target_file)
 
 
-def CopyBinaries(out_dir, out_project_dir, src_package, shared):
+def CopyBinaries(out_dir, out_project_dir, src_package, shared, no_icu_data):
   # Copy jar files to libs.
   libs_dir = os.path.join(out_project_dir, 'libs')
   if not os.path.exists(libs_dir):
@@ -121,14 +125,11 @@ def CopyBinaries(out_dir, out_project_dir, src_package, shared):
   if not os.path.exists(res_value_dir):
     os.mkdir(res_value_dir)
 
-  paks_to_copy = [
-      'icudtl.dat',
-      # Please refer to XWALK-3516, disable v8 use external startup data,
-      # reopen it if needed later.
-      # 'natives_blob.bin',
-      # 'snapshot_blob.bin',
+  paks = [
       'xwalk.pak',
   ]
+  if not no_icu_data:
+    paks.append('icudtl.dat')
 
   pak_list_xml = Document()
   resources_node = pak_list_xml.createElement('resources')
@@ -321,7 +322,7 @@ def main(argv):
   CopyProjectFiles(options.source, out_project_dir, options.shared)
   # Copy binaries and resuorces.
   CopyResources(options.source, out_dir, out_project_dir, options.shared)
-  CopyBinaries(out_dir, out_project_dir, options.src_package, options.shared)
+  CopyBinaries(out_dir, out_project_dir, options.src_package, options.shared, options.no_icu_data)
   # Copy JS API binding files.
   CopyJSBindingFiles(options.source, out_project_dir)
   # Remove unused files.

--- a/gyp_xwalk
+++ b/gyp_xwalk
@@ -351,7 +351,7 @@ if __name__ == '__main__':
     args.append('-Drelease_unwind_tables=0')
     #### Below flags are used for reducing size of Crosswalk Lite. ####
     # Disable ICU by default
-    args.append('-Duse_icu_alternatives_on_android=0')
+    args.append('-Duse_icu_alternatives_on_android=1')
     # Disable WebRTC by default
     args.append('-Denable_webrtc=0')
     # Disable XSLT by default

--- a/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
+++ b/runtime/android/core_internal/src/org/xwalk/core/internal/XWalkViewDelegate.java
@@ -53,7 +53,7 @@ class XWalkViewDelegate {
     // We should remove it from one of the places to avoid duplication.
     private static final String[] MANDATORY_PAKS = {
             "xwalk.pak",
-            "icudtl.dat",
+            //"icudtl.dat",//delete it when "use_icu_alternatives_on_android == 1"
             // Please refer to XWALK-3516, disable v8 use external startup data,
             // reopen it if needed later.
             // "natives_blob.bin",

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -334,6 +334,7 @@
             '../components/components.gyp:cdm_browser',
             'xwalk_core_jar_jni',
             'xwalk_core_native_jni',
+            '<(DEPTH)/base/base.gyp:base_icu_alternatives',
           ],
           'sources': [
             'experimental/native_file_system/virtual_root_provider_android.cc',

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -329,12 +329,16 @@
             '<@(speech_files)',
           ],
         }],
+        ['OS=="android" and use_icu_alternatives_on_android==1',{
+          'dependencies': [
+            '<(DEPTH)/base/base.gyp:base_icu_alternatives',
+          ],
+        }],
         ['OS=="android"',{
           'dependencies':[
             '../components/components.gyp:cdm_browser',
             'xwalk_core_jar_jni',
             'xwalk_core_native_jni',
-            '<(DEPTH)/base/base.gyp:base_icu_alternatives',
           ],
           'sources': [
             'experimental/native_file_system/virtual_root_provider_android.cc',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -313,7 +313,13 @@
             'base_inputs': [
               '<(dex_path)',
               '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/xwalk.pak',
-              '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/icudtl.dat',
+            ],
+            'conditions': [
+              ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
+                'base_inputs': [
+                  '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/icudtl.dat',
+                ],
+              }],
             ],
             'build_system_inputs': [
               '<@(base_inputs)',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -34,6 +34,33 @@
         'runtime/app/android/xwalk_jni_registrar.cc',
         'runtime/app/android/xwalk_jni_registrar.h',
       ],
+      'conditions': [
+        ['use_icu_alternatives_on_android==1', {
+          'dependencies': [
+            'cleanup_icu_data',
+          ],
+        }],
+      ],
+    },
+    {
+      'target_name': 'cleanup_icu_data',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'cleanup_icu_data',
+          'message': 'Cleanup icu data files',
+          'inputs': [
+            'build/android/clean_up_icu_data.py',
+          ],
+          'outputs': [
+            '<(PRODUCT_DIR)/cleanup_icu_data/always_run',
+          ],
+          'action': [
+            'python', 'build/android/clean_up_icu_data.py',
+            '--product-dir', '<(PRODUCT_DIR)',
+          ],
+        },
+      ],
     },
     {
       'target_name': 'xwalk_core_strings',

--- a/xwalk_android.gypi
+++ b/xwalk_android.gypi
@@ -255,7 +255,7 @@
           '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/xwalk.pak',
         ],
         'conditions': [
-          ['icu_use_data_file_flag==1', {
+          ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
             'additional_input_paths': [
               '<(PRODUCT_DIR)/xwalk_runtime_lib/assets/icudtl.dat',
             ],
@@ -327,7 +327,7 @@
             '<(PRODUCT_DIR)/xwalk.pak',
           ],
           'conditions': [
-            ['icu_use_data_file_flag==1', {
+            ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
               'files': [
                 '<(PRODUCT_DIR)/icudtl.dat',
               ],

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -55,7 +55,7 @@
           '<(PRODUCT_DIR)/xwalk_xwview/assets/jsapi/wifidirect_api.js',
         ],
         'conditions': [
-          ['icu_use_data_file_flag==1', {
+          ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
             'additional_input_paths': [
               '<(PRODUCT_DIR)/xwalk_xwview/assets/icudtl.dat',
             ],
@@ -101,7 +101,7 @@
             '<(PRODUCT_DIR)/xwalk.pak',
           ],
           'conditions': [
-            ['icu_use_data_file_flag==1', {
+            ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
               'files': [
                 '<(PRODUCT_DIR)/icudtl.dat',
               ],
@@ -349,7 +349,7 @@
           '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/www/manifest_xwalk_hosts.json',
         ],
         'conditions': [
-          ['icu_use_data_file_flag==1', {
+          ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
             'additional_input_paths': [
               '<(PRODUCT_DIR)/runtime_client_embedded_shell/assets/icudtl.dat',
             ],
@@ -413,7 +413,7 @@
             '<(PRODUCT_DIR)/xwalk.pak',
           ],
           'conditions': [
-            ['icu_use_data_file_flag==1', {
+            ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
               'files': [
                 '<(PRODUCT_DIR)/icudtl.dat',
               ],
@@ -568,7 +568,7 @@
           '<(PRODUCT_DIR)/sample/assets/xwalk.pak',
         ],
         'conditions': [
-          ['icu_use_data_file_flag==1', {
+          ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
             'additional_input_paths': [
               '<(PRODUCT_DIR)/sample/assets/icudtl.dat',
             ],
@@ -600,7 +600,7 @@
             '<(PRODUCT_DIR)/xwalk.pak',
           ],
           'conditions': [
-            ['icu_use_data_file_flag==1', {
+            ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
               'files': [
                 '<(PRODUCT_DIR)/icudtl.dat',
               ],

--- a/xwalk_android_tests.gypi
+++ b/xwalk_android_tests.gypi
@@ -636,7 +636,7 @@
           '<(PRODUCT_DIR)/xwalk_internal_xwview/assets/xwalk.pak',
         ],
         'conditions': [
-          ['icu_use_data_file_flag==1', {
+          ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
             'additional_input_paths': [
               '<(PRODUCT_DIR)/xwalk_internal_xwview/assets/icudtl.dat',
             ],
@@ -673,7 +673,7 @@
             '<(PRODUCT_DIR)/xwalk.pak',
           ],
           'conditions': [
-            ['icu_use_data_file_flag==1', {
+            ['icu_use_data_file_flag==1 and use_icu_alternatives_on_android!=1', {
               'files': [
                 '<(PRODUCT_DIR)/icudtl.dat',
               ],

--- a/xwalk_core_library_android.gypi
+++ b/xwalk_core_library_android.gypi
@@ -298,6 +298,17 @@
         'xwalk_core_shell_apk',
         'xwalk_core_library_java',
       ],
+      'conditions': [
+        ['use_icu_alternatives_on_android==1', {
+          'variables': {
+            'icu_data_param': '--no-icu-data',
+          },
+        }, {
+          'variables': {
+            'icu_data_param': '',
+          },
+        }],
+      ],
       'actions': [
         {
           'action_name': 'generate_xwalk_core_library',
@@ -312,7 +323,8 @@
           'action': [
             'python', '<(DEPTH)/xwalk/build/android/generate_xwalk_core_library.py',
             '-s', '<(DEPTH)',
-            '-t', '<(PRODUCT_DIR)'
+            '-t', '<(PRODUCT_DIR)',
+            '<(icu_data_param)'
           ],
         },
       ],


### PR DESCRIPTION
Porting from Lite-15 into Lite-17.  Controlled by flag: use_icu_alternatives_on_android
XWalkCoreShell.apk(ARM), reduced size=22.2 -15.7 = 6.5M
